### PR TITLE
Redefine "sortkey" and "distribution" columns in _date_fact NDTs

### DIFF
--- a/fb_account_fact.view.lkml
+++ b/fb_account_fact.view.lkml
@@ -59,6 +59,7 @@ view: fb_account_date_fact {
     datagroup_trigger: facebook_ads_etl_datagroup
     explore_source: fb_ad_impressions {
       column: _date { field: fact.date_date }
+      column: _date_raw { field: fact.date_raw }
       column: account_id { field: fact.account_id }
       column: account_name { field: fact.account_name }
       column: clicks {field: fact.total_clicks }
@@ -66,8 +67,12 @@ view: fb_account_date_fact {
       column: conversionvalue {field: fact.total_conversionvalue}
       column: cost {field: fact.total_cost}
       column: impressions { field: fact.total_impressions}
-      column: _distribution_alias {field: fact.date_raw }
-      column: _sortkey_alias {field: fact.date_raw }
+      derived_column: _distribution_alias {
+        sql: _date_raw ;;
+      }
+      derived_column: _sortkey_alias {
+        sql: _date_raw ;;
+      }
     }
   }
   dimension: account_id {

--- a/fb_ad_fact.view.lkml
+++ b/fb_ad_fact.view.lkml
@@ -67,8 +67,12 @@ view: fb_ad_date_fact {
     explore_source: fb_ad_impressions {
       column: ad_id { field: fact.ad_id }
       column: ad_name { field: fact.ad_name }
-      column: _distribution {field: fact.ad_id}
-      column: _sortkey {field: fact.ad_id}
+      derived_column: _distribution_alias {
+        sql: ad_id ;;
+      }
+      derived_column: _sortkey_alias {
+        sql: ad_id ;;
+      }
   }
   }
   dimension: ad_id {

--- a/fb_adset_fact.view.lkml
+++ b/fb_adset_fact.view.lkml
@@ -65,8 +65,12 @@ view: fb_adset_date_fact {
     explore_source: fb_ad_impressions {
       column: adset_id { field: fact.adset_id }
       column: adset_name { field: fact.adset_name }
-      column: _distribution_alias {field: fact.adset_id }
-      column: _sortkey_alias {field: fact.adset_id }
+      derived_column: _distribution_alias {
+        sql: adset_id ;;
+      }
+      derived_column: _sortkey_alias {
+        sql: adset_id ;;
+      }
     }
   }
   dimension: adset_id {

--- a/fb_campaign_fact.view.lkml
+++ b/fb_campaign_fact.view.lkml
@@ -62,8 +62,12 @@ view: fb_campaign_date_fact {
     explore_source: fb_ad_impressions {
       column: campaign_id { field: fact.campaign_id }
       column: campaign_name { field: fact.campaign_name }
-      column: _distribution {field: fact.campaign_id}
-      column: _sortkey {field: fact.campaign_id}
+      derived_column: _distribution_alias {
+        sql: campaign_id ;;
+      }
+      derived_column: _sortkey_alias {
+        sql: campaign_id ;;
+      }
     }
   }
   dimension: campaign_id {


### PR DESCRIPTION
Problem: The "Campaigns" tile on the "Facebook Overview" page was showing a `Name campaign_id not found inside fact at [23:43]` error. Turns out, the NDT in question did not have a column named "campaign_id" after being built even though there was a column named "campaign_id" defined, and that field is required in a join. In doing more digging, we found that if multiple columns in an NDT referenced the same field, only one of those columns would be built during PDT generation (more specifically, the LAST column parameter defined with the field is the name of the resulting column in the derived table). What this means is that because our "sortkey" and "distribution" columns were referencing the same field(s) as other columns in our NDTs, something was getting chopped out during PDT generation.

Solution: Adding derived columns  to each of our _date_fact NDTs means that there we don't run into the issue above, since we're NOT referencing a Looker field multiple times as with regular column parameters.